### PR TITLE
fix: update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/beer-tracker.yml
+++ b/.github/workflows/beer-tracker.yml
@@ -55,7 +55,7 @@ jobs:
         fi
 
     - name: Upload tracking data as artifact (backup)
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: beer-tracking-data
         path: beer_tracking.duckdb


### PR DESCRIPTION
Replace deprecated v3 with v4 to fix workflow failure.