### PR TITLE
fix: add write permissions for GitHub Actions

### DIFF
--- a/.github/workflows/beer-tracker.yml
+++ b/.github/workflows/beer-tracker.yml
@@ -12,6 +12,8 @@ env:
 jobs:
   track-beers:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Add contents: write permission to allow GitHub Actions bot to push database commits.